### PR TITLE
Don't use go 1.22.5

### DIFF
--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -72,7 +72,6 @@ else
         --suppress-variables ${EXTRA_CB_OPTIONS:-} \
         --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml" \
         --extra-meta flow_run_id="${flow_run_id:-}" remote_url="${remote_url:-}" sha="${sha:-}"
-
     ( startgroup "Inspecting artifacts" ) 2> /dev/null
 
     # inspect_artifacts was only added in conda-forge-ci-setup 4.6.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 4cd49f7230eaa81bbed7d98c48bfb8536c84f7a8e6607a1824be6097aca6c859
 
 build:
-  number: 1
+  number: 2
 
 outputs:
   - name: libadbc-driver-manager
@@ -56,7 +56,7 @@ outputs:
         - {{ compiler('cgo') }}
         - {{ stdlib("c") }}
         - cmake
-        - go-cgo >=1.18
+        - go-cgo <1.22.5
         - ninja
     build:
       # XXX: punting on non-unix platforms due to general issues
@@ -165,7 +165,7 @@ outputs:
         - {{ compiler('cgo') }}
         - {{ stdlib("c") }}
         - cmake
-        - go-cgo >=1.18
+        - go-cgo <1.22.5
         - ninja
     build:
       # XXX: punting on non-unix platforms due to general issues


### PR DESCRIPTION
Due to https://github.com/golang/go/issues/68587

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
